### PR TITLE
Improve GitHub Actions for deploying to GH Pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,53 +1,66 @@
-name: github pages
+name: Build and Deploy to GitHub Pages
 
 on:
   push:
     branches:
-    - main
-  pull_request:
+      - main
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  deploy:
+  # Build Job
+  build:
     runs-on: ubuntu-22.04
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true  # Fetch Hugo themes (true OR recursive)
-        fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
+      - uses: actions/checkout@v3
+        with:
+          submodules: true # Fetch Hugo themes (true OR recursive)
+          fetch-depth: 0 # Fetch all history for .GitInfo and .Lastmod
 
-    - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
-      with:
-        hugo-version: '0.102.3'
-        extended: true
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: "0.102.3"
+          extended: true
 
-    # install npm dependencies
-    - name: Setup Node
-      uses: actions/setup-node@v2
-      with:
-        node-version: '16'
-    - name: Cache dependencies
-      uses: actions/cache@v2
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
-    - run: npm install
-    - run: npm ci
+      # install npm dependencies
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: npm install
+      - run: npm ci
 
-    - name: Build
-      run: hugo --minify
+      - name: Build
+        run: hugo --minify
 
-    - name: Deploy
-      uses: peaceiris/actions-gh-pages@v3
-      if: github.ref == 'refs/heads/main'
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./public
-        # cname: docs.kcp.io
+      - name: Upload build artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: public/
+
+  # Deployment Job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-22.04
+    needs: build
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
## Changes

- The older method uses gh-pages branch to deploy to GitHub Pages
- New method directly deploys to GitHub Pages from the GitHub Actions
- Refer: https://github.com/actions/deploy-pages
- Refer: https://github.blog/2022-08-10-github-pages-now-uses-actions-by-default

## Preparation

1. Go to repository `Settings`
2. Got to `Pages` sections
3. Change the `Source` to `GitHub Actions`

Signed-off-by: Avinal Kumar <avinal@redhat.com>
