### PR TITLE
Fix link rendering

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,1 +1,0 @@
-<a href="{{ (.Page.GetPage .Destination).RelPermalink | safeURL }}">{{ .Text | safeHTML }}</a>


### PR DESCRIPTION
Remove the custom link rendering hook as that broke rendering all external links.

Signed-off-by: Andy Goldstein <andy.goldstein@redhat.com>