### PR TITLE
Use correct baseURL for kcp.io

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = 'http://kcp-dev.github.io/'
+baseURL = 'https://kcp.io'
 contentDir = "content/en"
 defaultContentLanguage = "en"
 defaultContentLanguageInSubdir = false


### PR DESCRIPTION
For local builds / `hugo serve` everything was working fine, but the production deployment uses the `baseURL`. So e.g. links to blog posts are 404'ing right now. This fixes that oversight.