### PR TITLE
Add kcp maintainers and embik as code owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- clubanderson
+- embik
+- scheeles
+- sttts


### PR DESCRIPTION
We just completed onboarding of this repository to the kcp community prow, so we also need an OWNERS file. This adds it.

I took the liberty to add myself to the list so I can get smaller improvements / fixes merged without bothering a core maintainer, but I can also see that the public-facing part of kcp should not be easily accessible. I can remove myself from the list if this is not wanted.