### PR TITLE
Improve README and home page title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
-# kcp Documentation
+# kcp.io
 
-This repository contains the documentation for the [kcp](https://github.com/kcp-dev/kcp). It is published to https://kcp-dev.github.io, which is soon supposed to be available under https://docs.kcp.io.
+This repository contains the [Hugo](https://gohugo.io) files for [kcp.io](https://kcp.io), the official website of the kcp project.
+
+## Development
+
+To set up a local development environment, make sure to have `git`, `npm` and `hugo` available. After checking out the repository, make sure dependencies and submodules are pulled:
+
+```sh
+$ npm ci && git submodule update --init
+```
+
+Afterwards, run `hugo` and visit [localhost:1313](http://localhost:1313):
+
+```sh
+$ hugo serve
+```

--- a/config.toml
+++ b/config.toml
@@ -46,7 +46,7 @@ title = 'kcp.io'
 languageName = "English"
 weight = 1
 [languages.en.params]
-description = "kcp documentation"
+description = "Horizontally Scalable Control Plane for Kubernetes APIs"
 
 [markup]
 [markup.goldmark]

--- a/content/en/blog/_index.md
+++ b/content/en/blog/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "kcp Blog"
+title: "Blog"
 linkTitle: "Blog"
 menu:
   main:

--- a/themes/kcp/layouts/partials/head.html
+++ b/themes/kcp/layouts/partials/head.html
@@ -9,7 +9,15 @@
     {{ template "_internal/twitter_cards.html" . }}
     {{- partial "favicons.html" }}
     <title>{{ block "title" . }}
-        {{ .Site.Title }}
+        {{ if .IsHome }}
+            {{ if .Site.Params.Description }}
+                {{ .Site.Params.Description }} -  {{ .Site.Title }}
+            {{ else }}
+                {{ .Site.Title }}
+            {{ end }}
+        {{ else }}
+            {{ .Title }} - {{ .Site.Title }}
+        {{ end }}
     {{ end }}</title>
     {{- partialCached "css.html" . }}
     {{ $alpineJs := resources.Get "js/alpine.min.js" | fingerprint }}


### PR DESCRIPTION
This is a little improvements PR bundling two things:

1. The README.md was outdated, this updates it at least with some basic information how to get a local development setup running.
2. It updates the site title for the home page from "kcp.io" to "Horizontally Scalable Control Plane for Kubernetes APIs - kcp.io" by fine-tuning templates and the "description" parameter.