### PR TITLE
📖 Correct information about community meeting

### DIFF
--- a/data/home/data.yaml
+++ b/data/home/data.yaml
@@ -48,6 +48,5 @@ community:
 
     [![Grid of contributors on GitHub](https://contrib.rocks/image?repo=kcp-dev/kcp&amp;columns=10&amp;max=100 "Contributor Grid")](https://github.com/kcp-dev/kcp/graphs/contributors)
 
-    We have a weekly community meeting: every Thursday 11am EST. Join us live! The [agenda is available as a Google doc](https://docs.google.com/document/d/1PrEhbmq1WfxFv1fTikDBZzXEIJkUWVHdqDFxaY1Ply4). For past meetings, see the [recordings on YouTube](https://www.youtube.com/channel/UCfP_yS5uYix0ppSbm2ltS5Q).
-
+    We have a bi-weekly community meeting: every second Thursday at 11am EST (3pm UTC). Join us live! Agenda and next dates are available as a [Google doc](https://docs.google.com/document/d/1PrEhbmq1WfxFv1fTikDBZzXEIJkUWVHdqDFxaY1Ply4). For past meetings, see the [recordings on YouTube](https://www.youtube.com/channel/UCfP_yS5uYix0ppSbm2ltS5Q).
 


### PR DESCRIPTION
For some reason, I put weekly instead of bi-weekly for our community meeting. Might have been copied from an old version of the website.

This fixes that oversight and adds some more context (meeting time in UTC, what to find in the Google doc).