### PR TITLE
Add blog post for kcp at KubeCon EU 2024

### DIFF
--- a/content/en/blog/news/2024-02-kcp-at-kubecon-paris.md
+++ b/content/en/blog/news/2024-02-kcp-at-kubecon-paris.md
@@ -1,0 +1,24 @@
+---
+title: "Our Schedule at KubeCon + CloudNativeCon Europe 2024"
+linkTitle: "Our Schedule at KubeCon + CloudNativeCon Europe 2024"
+slug: kcp-at-kubecon-cloudnativecon-eu-2024
+date: 2024-02-20
+tags:
+  - cncf
+  - community
+  - kubecon
+  - cloudnativecon
+  - talks
+  - conference
+---
+
+[KubeCon + CloudNativeCon Europe 2024](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/) is around the corner and we can't wait to see you all in Paris!
+
+We are happy to tell you that kcp and its maintainers will be present and hope to chat a lot about the project. This is kcp's first KubeCon + CloudNativeCon as [CNCF Sandbox project]({{< relref "./2024-01-joining-the-cncf-sandbox.md" >}}).
+
+Currently, the following sessions will involve kcp (schedule might be subject to change):
+
+- **Mar 18, 5:40pm**: [**Unlocking New Possibilities: Bridging Linux and Kubernetes**](https://cfp.cloud-native.rejekts.io/cloud-native-rejekts-eu-paris-2024/talk/JUBTCX/) at [Cloud Native Rejekts](https://cloud-native.rejekts.io/) -- Mangirdas Judeikis
+- **Mar 19, 11:05am**: [**Building a Platform Engineering API Layer with kcp**](https://colocatedeventseu2024.sched.com/event/1YFfY/building-a-platform-engineering-api-layer-with-kcp-marvin-beckers-kubermatic-gmbh) at CNCF-hosted co-located event [Platform Engineering Day](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/co-located-events/platform-engineering-day/) -- Marvin Beckers
+- **Mar 21, 3:25pm**: [**Why Kubernetes Is Inappropriate for Platforms, and How to Make It Better.**](https://kccnceu2024.sched.com/event/1YePC) at KubeCon + CloudNativeCon -- Stefan Schimanski, Mangirdas Judeikis, Sebastian Scheele
+

--- a/content/en/blog/news/2024-03-kcp-at-kubecon-paris.md
+++ b/content/en/blog/news/2024-03-kcp-at-kubecon-paris.md
@@ -2,7 +2,7 @@
 title: "Our Schedule at KubeCon + CloudNativeCon Europe 2024"
 linkTitle: "Our Schedule at KubeCon + CloudNativeCon Europe 2024"
 slug: kcp-at-kubecon-cloudnativecon-eu-2024
-date: 2024-02-20
+date: 2024-03-06
 tags:
   - cncf
   - community
@@ -12,13 +12,15 @@ tags:
   - conference
 ---
 
-[KubeCon + CloudNativeCon Europe 2024](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/) is around the corner and we can't wait to see you all in Paris!
+[KubeCon + CloudNativeCon Europe 2024](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/) is around the corner and we can't wait to see you in Paris!
 
-We are happy to tell you that kcp and its maintainers will be present and hope to chat a lot about the project. This is kcp's first KubeCon + CloudNativeCon as [CNCF Sandbox project]({{< relref "./2024-01-joining-the-cncf-sandbox.md" >}}).
+We are happy to tell you that kcp and several of its maintainers will be present and hope to chat a lot about the project. This will be kcp's first KubeCon + CloudNativeCon as [CNCF Sandbox project]({{< relref "./2024-01-joining-the-cncf-sandbox.md" >}}) and we couldn't be more excited about joining KubeCon + CloudNativeCon as a CNCF project.
 
-Currently, the following sessions will involve kcp (schedule might be subject to change):
+Currently, the following sessions will cover kcp (schedule might be subject to change):
 
 - **Mar 18, 5:40pm**: [**Unlocking New Possibilities: Bridging Linux and Kubernetes**](https://cfp.cloud-native.rejekts.io/cloud-native-rejekts-eu-paris-2024/talk/JUBTCX/) at [Cloud Native Rejekts](https://cloud-native.rejekts.io/) -- Mangirdas Judeikis
 - **Mar 19, 11:05am**: [**Building a Platform Engineering API Layer with kcp**](https://colocatedeventseu2024.sched.com/event/1YFfY/building-a-platform-engineering-api-layer-with-kcp-marvin-beckers-kubermatic-gmbh) at CNCF-hosted co-located event [Platform Engineering Day](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/co-located-events/platform-engineering-day/) -- Marvin Beckers
+- **Mar 19, 3:00pm**: [**Kubernetes-style APIs for SaaS-like Control Planes with kcp (Project Lightning Talk)**](https://kccnceu2024.sched.com/event/1aQhV) at KubeCon + CloudNativeCon -- Mangirdas Judeikis, Marvin Beckers
 - **Mar 21, 3:25pm**: [**Why Kubernetes Is Inappropriate for Platforms, and How to Make It Better.**](https://kccnceu2024.sched.com/event/1YePC) at KubeCon + CloudNativeCon -- Stefan Schimanski, Mangirdas Judeikis, Sebastian Scheele
 
+We hope to meet you all in Paris and discuss building the control plane of the future!

--- a/themes/kcp/layouts/_default/single.html
+++ b/themes/kcp/layouts/_default/single.html
@@ -5,7 +5,7 @@
 <div class="mx-auto max-w-screen-md px-4 py-16 sm:px-6 lg:px-8 text-lg">
     <h1 class="text-3xl font-extrabold sm:text-4xl">{{ .Title }}</h1>
     <time class="text-gray-700/75">{{ .Date.Format "Monday Jan 2, 2006" }}</time>
-    <div class="leading-7 mt-8 space-y-4 [&>h1]:text-2xl [&>h1]:font-bold [&>h2]:text-xl [&>h2]:font-bold [&>h3]:text-lg [&>h3]:font-bold [&>ul]:list-disc [&>ul]:ml-8 [&>ol]:list-decimal [&>ol]:ml-8 [&>p>a]:text-cyan-600 [&>p>*>a]:text-cyan-600 [&>*>img]:m-4">
+    <div class="leading-7 mt-8 space-y-4 [&>h1]:text-2xl [&>h1]:font-bold [&>h2]:text-xl [&>h2]:font-bold [&>h3]:text-lg [&>h3]:font-bold [&>ul]:list-disc [&>ul]:ml-8 [&>ul>*>a]:text-cyan-600 [&>ol]:list-decimal [&>ol]:ml-8 [&>*>a]:text-cyan-600 [&>*>img]:m-4">
         {{ .Content }}
     </div>
 </div>


### PR DESCRIPTION
This adds a blog post for our KubeCon + CloudNativeCon EU presence, listing all the sessions that maintainers are hosting this year.

Also slightly updates the stylesheet so that links are properly colored.