### PR TITLE
Refresh references on kcp.io

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -58,7 +58,7 @@ style = "monokai"
 guessSyntax = "true"
 
 [params]
-copyright = "2021-2023. The kcp Authors"
+copyright = "2021-2024. The kcp Authors"
 footer_note = "Kubernetes and the Kubernetes logo are registered trademarks of The Linux Foundation® (TLF)."
 footer_cncf_show = true
 footer_cncf_note = "We are a Cloud Native Computing Foundation sandbox project."
@@ -81,7 +81,7 @@ prism_syntax_highlighting = false
 [[menu.main]]
 name = "Documentation"
 weight = -1000
-url = "https://docs.kcp.io/kcp/main"
+url = "https://docs.kcp.io/kcp/v0.22"
 [[menu.main]]
 name = "GitHub"
 weight = -99

--- a/data/home/data.yaml
+++ b/data/home/data.yaml
@@ -48,5 +48,5 @@ community:
 
     [![Grid of contributors on GitHub](https://contrib.rocks/image?repo=kcp-dev/kcp&amp;columns=10&amp;max=100 "Contributor Grid")](https://github.com/kcp-dev/kcp/graphs/contributors)
 
-    We have a bi-weekly community meeting: every second Thursday at 11am EST (3pm UTC). Join us live! Agenda and next dates are available as a [Google doc](https://docs.google.com/document/d/1PrEhbmq1WfxFv1fTikDBZzXEIJkUWVHdqDFxaY1Ply4). For past meetings, see the [recordings on YouTube](https://www.youtube.com/channel/UCfP_yS5uYix0ppSbm2ltS5Q).
+    We have a bi-weekly community meeting: every second Thursday at 11am EST (5pm CET). Join us live! Agenda and next dates are available as a [Google doc](https://docs.google.com/document/d/1PrEhbmq1WfxFv1fTikDBZzXEIJkUWVHdqDFxaY1Ply4). For past meetings, see the [recordings on YouTube](https://www.youtube.com/channel/UCfP_yS5uYix0ppSbm2ltS5Q).
 

--- a/data/home/data.yaml
+++ b/data/home/data.yaml
@@ -3,8 +3,8 @@ hero:
   subheader: "Together."
   tagline: "An Open Source horizontally scalable Control Plane for Kubernetes APIs"
   buttons:
-    get_started: https://docs.kcp.io/kcp/v0.20/#quickstart
-    learn_more: https://docs.kcp.io/kcp/v0.20/concepts/
+    get_started: https://docs.kcp.io/kcp/v0.22/#quickstart
+    learn_more: https://docs.kcp.io/kcp/v0.22/concepts/
 
 
 cards:


### PR DESCRIPTION
This refreshes a few references we have on kcp.io:

- It's 2024.
- Our newest release is 0.22.
- The time zone change I did a while back to UTC was a mistake, because now the time is incorrect (it would be at 4pm UTC). We should just leave the regional time zone information.