### PR TITLE
Update documentation link to 0.23 docs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -81,7 +81,7 @@ prism_syntax_highlighting = false
 [[menu.main]]
 name = "Documentation"
 weight = -1000
-url = "https://docs.kcp.io/kcp/v0.22"
+url = "https://docs.kcp.io/kcp/v0.23"
 [[menu.main]]
 name = "GitHub"
 weight = -99


### PR DESCRIPTION
Small update to the top level navigation link to our docs so they point to the up-to-date v0.23 docs. There are more links, but I've already updated them in #35 and do not want to create a merge conflict.

/cc @xrstf 