### PR TITLE
Link to 'latest' alias on docs.kcp.io

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -81,7 +81,7 @@ prism_syntax_highlighting = false
 [[menu.main]]
 name = "Documentation"
 weight = -1000
-url = "https://docs.kcp.io/kcp/v0.23"
+url = "https://docs.kcp.io/kcp/latest"
 [[menu.main]]
 name = "GitHub"
 weight = -99

--- a/data/home/data.yaml
+++ b/data/home/data.yaml
@@ -3,8 +3,8 @@ hero:
   subheader: "Together."
   tagline: "An open source horizontally scalable control plane for Kubernetes-like APIs."
   buttons:
-    get_started: https://docs.kcp.io/kcp/v0.23/#quickstart
-    learn_more: https://docs.kcp.io/kcp/v0.23/concepts/
+    get_started: https://docs.kcp.io/kcp/latest/setup/quickstart/
+    learn_more: https://docs.kcp.io/kcp/latest/concepts/
 
 cards:
   - title: "A Framework for Platforms"


### PR DESCRIPTION
https://github.com/kcp-dev/kcp/pull/3102 (and follow-up PRs) added an "latest" alias to our documentation. This updates the url on kcp.io to that alias, so we no longer have to manually bump the url every time we cut a new release.