### PR TITLE
Advertise CNCF community group on kcp.io

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -113,8 +113,8 @@ url = "https://www.youtube.com/channel/UCfP_yS5uYix0ppSbm2ltS5Q"
 [params.links.footer.community]
 name = "Community"
 [[params.links.footer.community.links]]
-name = "Code of Conduct"
-url = "https://github.com/kcp-dev/kcp/blob/main/code-of-conduct.md"
+name = "CNCF Community Group"
+url = "https://community.cncf.io/kcp/"
 [[params.links.footer.community.links]]
 name = "Kubernetes Slack"
 url = "https://kubernetes.slack.com/archives/C021U8WSAFK"
@@ -145,6 +145,9 @@ url = "https://github.com/kcp-dev/kcp/blob/main/SECURITY.md"
 
 [params.links.footer.policies]
 name = "Policies"
+[[params.links.footer.policies.links]]
+name = "Code of Conduct"
+url = "https://github.com/kcp-dev/kcp/blob/main/code-of-conduct.md"
 [[params.links.footer.policies.links]]
 name = "Governance"
 url = "https://github.com/kcp-dev/kcp/blob/main/GOVERNANCE.md"

--- a/data/home/data.yaml
+++ b/data/home/data.yaml
@@ -47,5 +47,5 @@ community:
 
     [![Grid of contributors on GitHub](https://contrib.rocks/image?repo=kcp-dev/kcp&amp;columns=15&amp;max=100 "Contributor Grid")](https://github.com/kcp-dev/kcp/graphs/contributors)
 
-    We have a bi-weekly community meeting: every second Thursday at 11am EST (5pm CET). Join us live! Agenda and next dates are available as a [Google doc](https://docs.google.com/document/d/1PrEhbmq1WfxFv1fTikDBZzXEIJkUWVHdqDFxaY1Ply4). For past meetings, see the [recordings on YouTube](https://www.youtube.com/channel/UCfP_yS5uYix0ppSbm2ltS5Q).
+    We have a bi-weekly community meeting: every second Thursday at 11am EST (5pm CET). Join us live! Agenda and next dates are available as a [Google doc](https://docs.google.com/document/d/1PrEhbmq1WfxFv1fTikDBZzXEIJkUWVHdqDFxaY1Ply4). You can also find upcoming meetings on our [CNCF community page](https://community.cncf.io/kcp/). For past meetings, see the [recordings on YouTube](https://www.youtube.com/channel/UCfP_yS5uYix0ppSbm2ltS5Q).
 


### PR DESCRIPTION
We currently don't mention https://community.cncf.io/kcp/ at all on our website, so this adds the community group to a) the section that advertises the community meeting and b) the footer (by shifting "Code of Conduct" to the "Policies" section).