### PR TITLE
Update OWNERS to include 'new' kcp maintainers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,7 @@
 approvers:
 - clubanderson
-- embik
 - scheeles
 - sttts
+- xrstf
+- mjudeikis
+- embik


### PR DESCRIPTION
We haven't updated the `OWNERS` file in this repository since https://github.com/kcp-dev/kcp/commit/f7ad0a1cf063be0ca0246dc135b42e38f7bc8262.