### PR TITLE
Fix typos in the KubeCon EU 2025 blog post

### DIFF
--- a/content/en/blog/news/2025-03-kcp-at-kubecon-london.md
+++ b/content/en/blog/news/2025-03-kcp-at-kubecon-london.md
@@ -18,11 +18,11 @@ authors:
 
 The kcp project has prepared a lot of exiciting content and activites for this year's KubeCon EU. Just like at KubeCon NA last year, you'll have a chance to meet our maintainers at the **Project Pavilion** on **Wednesday, April 2, from 15:30 to 19:45 BST at the Kiosk 5A**. Feel free to drop by and talk anything about kcp or just say hi. 👋
 
-We're very excited to present our [first hands-on workshop](https://sched.co/1tx6b) where attendees will have a chance to get familiar with multi-tenant Kubernetes APIs and controllers with kcp, while being guided by our maintainers and contributors. Join Robert Vasek, Nabarun Pal, Varsha Narsing, Marko Mudrinić, and Mangirdas Judeikis, at 11:15 BST for tons of learning and fun!
+We're very excited to present our [first hands-on workshop](https://sched.co/1tx6b) where attendees will have a chance to get familiar with multi-tenant Kubernetes APIs and controllers with kcp, while being guided by our maintainers and contributors. Join Robert Vasek, Nabarun Pal, Varsha Narsing, Marko Mudrinić, and Mangirdas Judeikis, on **Wednesday, April 2, at 11:15 BST** for tons of learning and fun!
 
 But that's not all, we're having two more kcp talks at KubeCon:
 
 - [Thrusday, April 3, 11:00 - 11:30 BST: Extending Kubernetes Resource Model (KRM) Beyond Kubernetes Workloads](https://sched.co/1txAB) - Mangirdas Judeikis, Cast AI & Nabarun Pal, Independent
 - [Thrusday, April 3, 15:00 - 15:30 BST: Dynamic Multi-Cluster Controllers With Controller-runtime](https://sched.co/1txFM) - Marvin Beckers, Kubermatic & Stefan Schimanski, NVIDIA
 
-We hope that you're thrilled for the KubeCon as much as we are! See you there!
+We hope that you’re as thrilled for KubeCon as we are! See you there!


### PR DESCRIPTION
- I forgot to mention that the workshop is on Wednesday
- I made a typo in the last paragraph (an unnecessary `the` and a weird construction of the sentence)