### PR TITLE
add styling for tables

### DIFF
--- a/themes/kcp/layouts/_default/single.html
+++ b/themes/kcp/layouts/_default/single.html
@@ -5,7 +5,8 @@
 <div class="mx-auto max-w-screen-md px-4 py-16 sm:px-6 lg:px-8 text-lg">
     <h1 class="text-3xl font-extrabold sm:text-4xl">{{ .Title }}</h1>
     <time class="text-gray-700/75">{{ .Date.Format "Monday Jan 2, 2006" }}</time>
-    <div class="leading-7 mt-8 space-y-4 [&>h1]:text-2xl [&>h1]:font-bold [&>h2]:text-xl [&>h2]:font-bold [&>h3]:text-lg [&>h3]:font-bold [&>ul]:list-disc [&>ul]:ml-8 [&>ul>*>a]:text-cyan-600 [&>ol]:list-decimal [&>ol]:ml-8 [&>*>a]:text-cyan-600 [&>*>img]:m-4">
+    <div
+        class="leading-7 mt-8 space-y-4 overflow-x-auto [&>h1]:text-2xl [&>h1]:font-bold [&>h2]:text-xl [&>h2]:font-bold [&>h3]:text-lg [&>h3]:font-bold [&>ul]:list-disc [&>ul]:ml-8 [&>ul>*>a]:text-cyan-600 [&>ol]:list-decimal [&>ol]:ml-8 [&>*>a]:text-cyan-600 [&>*>img]:m-4 [&_table]:w-full [&_table]:border-collapse [&_table]:my-4 [&_table]:text-sm [&_th]:border [&_th]:border-gray-300 [&_th]:bg-gray-100 [&_th]:px-4 [&_th]:py-2 [&_th]:text-left [&_th]:font-semibold [&_td]:border [&_td]:border-gray-300 [&_td]:px-4 [&_td]:py-2">
         {{ .Content }}
     </div>
     {{ if .Params.authors }}


### PR DESCRIPTION
Adds some basic styling for tables, so they don't look like an absolute mess

**before:**

<img width="737" height="410" alt="grafik" src="https://github.com/user-attachments/assets/9b04e13b-05af-4c11-812e-f3af984bb803" />

**after:**

<img width="716" height="458" alt="grafik" src="https://github.com/user-attachments/assets/639ef106-f45e-41f5-93af-47fadcc55436" />
